### PR TITLE
Bug Fix: Upload Missing Fragment Web Profile View

### DIFF
--- a/app/src/main/res/layout/fragment_web_profile_view.xml
+++ b/app/src/main/res/layout/fragment_web_profile_view.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+        <WebView
+            android:id="@+id/webView"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>


### PR DESCRIPTION
## PR Summary:
This PR addresses a bug where the fragment_web_profile_view was mistakenly not uploaded. The missing fragment caused errors in the application due to incomplete navigation flow. By uploading the missing fragment, the application's navigation flow is restored, ensuring users can access the web profile view without encountering errors.

## Changes Include:

Uploaded the missing fragment_web_profile_view to the project repository.
## Conclusion:
This PR quickly resolves a critical bug by providing the missing fragment_web_profile_view, ensuring the application's navigation flow is complete and users can access the web profile view without encountering errors.